### PR TITLE
Scripting and Pretty Print $HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ KUBECTL_BIN ?= $(OUTPUT_DIR)/kubectl-$(APP)
 GO_FLAGS ?= -v -mod=vendor
 GO_TEST_FLAGS ?= -race -cover
 
+GO_CACHE ?= $(shell go env GOCACHE)
+
 ARGS ?=
 
 # Tekton and Shipwright Build Controller versions for CI
@@ -67,10 +69,14 @@ install-shipwright:
 sanity-check:
 	golangci-lint run
 
+# generates the command-line help messages as markdown files, and in order to have a generic ${HOME}
+# rendered, it exports a fake home directory ("~"), and preserves the original GOCACHE to avoid
+# creating bogus files on the project directory.
 .PHONY: generate-docs
 generate-docs:
-	go run cmd/help/main.go --dir ./docs
+	GOCACHE="$(GO_CACHE)" HOME="~" go run cmd/help/main.go --output-dir=./docs
 
+# checks if the generated documentation files are out of sync.
 .PHONY: verify-docs
-verify-docs:
+verify-docs: generate-docs
 	./hack/verify-docs.sh

--- a/cmd/help/main.go
+++ b/cmd/help/main.go
@@ -10,27 +10,34 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-var dir string
+// outputDirPath stores the path to the output directory.
+var outputDirPath string
+
 var root = &cobra.Command{
 	Use:   "gendoc",
-	Short: "Generate shp's help docs",
+	Short: "Generate shp's command-line help messages as markdown",
 	Args:  cobra.NoArgs,
-	RunE: func(*cobra.Command, []string) error {
-		genericOpts := &genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-		cmd := cmd.NewCmdSHP(genericOpts)
-		cmd.DisableAutoGenTag = true
-		return doc.GenMarkdownTree(cmd, dir)
+	RunE: func(_ *cobra.Command, _ []string) error {
+		genericOpts := &genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stdout}
+		shpCmd := cmd.NewCmdSHP(genericOpts)
+		shpCmd.DisableAutoGenTag = true
+		return doc.GenMarkdownTree(shpCmd, outputDirPath)
 	},
 }
 
 func init() {
-	os.Setenv("HOME", "~")
-	root.Flags().StringVarP(&dir, "dir", "d", ".", "Path to directory in which to generate docs")
+	root.Flags().StringVarP(
+		&outputDirPath,
+		"output-dir",
+		"o",
+		".",
+		"Path to output direcotry for generated markdown files",
+	)
 }
 
 func main() {
 	if err := root.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/docs/shp.md
+++ b/docs/shp.md
@@ -11,7 +11,7 @@ shp [command] [resource] [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_build.md
+++ b/docs/shp_build.md
@@ -17,7 +17,7 @@ shp build [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_build_create.md
+++ b/docs/shp_build_create.md
@@ -41,7 +41,7 @@ shp build create <name> [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_build_delete.md
+++ b/docs/shp_build_delete.md
@@ -18,7 +18,7 @@ shp build delete <name> [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_build_list.md
+++ b/docs/shp_build_list.md
@@ -18,7 +18,7 @@ shp build list [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_build_run.md
+++ b/docs/shp_build_run.md
@@ -37,7 +37,7 @@ shp build run <name> [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_build_upload.md
+++ b/docs/shp_build_upload.md
@@ -42,7 +42,7 @@ shp build upload <build-name> [path/to/source|.] [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_buildrun.md
+++ b/docs/shp_buildrun.md
@@ -17,7 +17,7 @@ shp buildrun [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_buildrun_cancel.md
+++ b/docs/shp_buildrun_cancel.md
@@ -17,7 +17,7 @@ shp buildrun cancel <name> [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_buildrun_create.md
+++ b/docs/shp_buildrun_create.md
@@ -36,7 +36,7 @@ shp buildrun create <name> [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_buildrun_delete.md
+++ b/docs/shp_buildrun_delete.md
@@ -17,7 +17,7 @@ shp buildrun delete <name> [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_buildrun_list.md
+++ b/docs/shp_buildrun_list.md
@@ -18,7 +18,7 @@ shp buildrun list [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/docs/shp_buildrun_logs.md
+++ b/docs/shp_buildrun_logs.md
@@ -18,7 +18,7 @@ shp buildrun logs <name> [flags]
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/home/vkochuku/.kube/cache")
+      --cache-dir string               Default cache directory (default "~/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/hack/verify-docs.sh
+++ b/hack/verify-docs.sh
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
 #
-# Verify that generated Markdown docs are up-to-date.
+# Verify that generated Markdown documentation fils are out of sync.
 #
 
-set -o errexit
-set -o nounset
-set -o pipefail
+set -eu -o pipefail
 
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-
-pushd "${PROJECT_ROOT}"
-trap popd EXIT
-
-tmpdir=$(mktemp -d)
-go run cmd/help/main.go --dir "$tmpdir"
-diff -Naur -x 'testing.md' "$tmpdir" docs/
+if ( git diff --name-only |grep -q '^docs\/' ) ; then
+	echo "[ERROR] Markdown documenation is out of sync, run 'make generate-docs' and commit the changes!"
+	exit 1
+fi


### PR DESCRIPTION
Tweaking the scripting and making sure `$HOME` is pretty printed as `~`. The changes here are part of [#94](https://github.com/shipwright-io/cli/pull/94) upstream.